### PR TITLE
💡 Feat: 게시물 업로드 앨범정보 파이어베이스 저장(#59)

### DIFF
--- a/src/components/Accordion/AccordionStyle.tsx
+++ b/src/components/Accordion/AccordionStyle.tsx
@@ -97,7 +97,7 @@ const MultiAccordionWrapper = styled.div`
     display: flex;
     flex-wrap: wrap;
     gap: 1.2rem;
-    max-height: 10rem;
+    max-height: 7rem;
     overflow-y: scroll;
     padding: 1rem 0;
 

--- a/src/components/Accordion/MultipleAccordion.tsx
+++ b/src/components/Accordion/MultipleAccordion.tsx
@@ -5,9 +5,16 @@ import Direction from '../../asset/icon/Arrow.svg';
 interface AccordionProps {
   question: string;
   answer: string;
+  selectedAlbum: string;
+  setSelectedAlbum: (album: string) => void;
 }
 
-function MultipleAccordion({ question, answer }: AccordionProps) {
+function MultipleAccordion({
+  question,
+  answer,
+  selectedAlbum,
+  setSelectedAlbum,
+}: AccordionProps) {
   const [isAccordionOpen, setIsAccordionOpen] = useState(false);
   const answerArray = answer.split(',');
   const [selectedTexts, setSelectedTexts] = useState<string[]>([
@@ -35,6 +42,9 @@ function MultipleAccordion({ question, answer }: AccordionProps) {
       // 선택되지 않은 텍스트일 경우 선택 상태로 업데이트
       setSelectedTexts([...selectedTexts, text]);
     }
+    // 여기에서 selectedAlbum을 업데이트합니다.
+    const updatedAlbum = selectedTexts.join(','); // 선택된 텍스트를 쉼표로 연결
+    setSelectedAlbum(updatedAlbum);
   };
 
   return (

--- a/src/components/Upload/Upload.tsx
+++ b/src/components/Upload/Upload.tsx
@@ -32,6 +32,7 @@ function Upload({ setOpenPopup, album }: Props) {
     useState<string>('');
   const [selectedEmotionImages, setSelectedEmotionImages] =
     useState<string>('');
+  const [selectedAlbum, setSelectedAlbum] = useState<string>('');
   const [file, setFile] = useState<FileList | null>(null);
   const { user } = useAuthContext();
   const [clientWitch, setClientWitch] = useState(
@@ -50,17 +51,6 @@ function Upload({ setOpenPopup, album }: Props) {
   }
 
   const [accordionData, setAccordionData] = useState<Object[]>([]);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      if (user) {
-        const result = await GetAccordionData(user);
-        console.log(result);
-        setAccordionData(result);
-      }
-    };
-    fetchData();
-  }, []);
 
   interface Object {
     question: string;
@@ -121,6 +111,7 @@ function Upload({ setOpenPopup, album }: Props) {
           selectedAddress: selectedAddress,
           weatherImages: selectedWeatherImages,
           emotionImages: selectedEmotionImages,
+          album: selectedAlbum,
           imageUrl: downloadURLs,
           id: id,
         };
@@ -206,6 +197,8 @@ function Upload({ setOpenPopup, album }: Props) {
                   key={0}
                   question={accordionData[0].question}
                   answer={accordionData[0].answer.join(',')}
+                  selectedAlbum={selectedAlbum || ''}
+                  setSelectedAlbum={setSelectedAlbum}
                 />
               ))}
               {accordionData.slice(1, 3).map((data, index) => (


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가

### 반영 브랜치
feat/upload -> main

### 변경 사항
- 앨범 선택시 해당 정보가 feed별 데이터베이스에 저장되도록 추가했습니다. 
- 업로드 내용 중 앨범 선택은 70px이 넘어가면 스크롤이 생기도록 수정했습니다. 



