### PR TITLE
:bulb: Feat:홈피드 데이터  업데이트시  리렌더링(#106)

### DIFF
--- a/src/components/Upload/accordionData.ts
+++ b/src/components/Upload/accordionData.ts
@@ -1,7 +1,7 @@
 import useGetAlbumList from '../../hooks/useGetAlbumList';
 
 const GetAccordionData = () => {
-  const getAlbumList = useGetAlbumList();
+  const { albumDataList, albumIdList } = useGetAlbumList();
 
   const getAccordionData = async () => {
     const accordionData = [
@@ -38,7 +38,6 @@ const GetAccordionData = () => {
     }
 
     const albumIdData: AlbumIdData[] = [];
-    const { albumDataList, albumIdList } = await getAlbumList();
 
     albumDataList.forEach((albumData, i) => {
       accordionData[0].answer.push(albumData.name);

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -19,28 +19,12 @@ export default function Home() {
   const [clientWitch, setClientWitch] = useState(
     document.documentElement.clientWidth,
   );
-  const [albumList, setAlbumList] = useState<DocumentData[]>([]);
-  const [oldestAlbumList, setOldestAlbumList] = useState<DocumentData[]>([]);
-  const getAlbumList = useGetAlbumList();
+  const { albumDataList, oldestAlbumList } = useGetAlbumList();
 
   useEffect(() => {
     window.addEventListener('resize', () => {
       setClientWitch(document.documentElement.clientWidth);
     });
-
-    (async () => {
-      const { albumDataList } = await getAlbumList();
-      setAlbumList(albumDataList);
-
-      const oldestAlbumListtoSet = [...albumDataList].reverse();
-      const allFeedsAlbumData = oldestAlbumListtoSet.pop();
-
-      if (allFeedsAlbumData) {
-        oldestAlbumListtoSet.unshift(allFeedsAlbumData);
-      }
-
-      setOldestAlbumList(oldestAlbumListtoSet);
-    })();
   }, []);
 
   const HandleArrayModal = () => {
@@ -75,15 +59,16 @@ export default function Home() {
             </button>
           </div>
           <ul>
-            {(selectedOption === 'oldest' ? oldestAlbumList : albumList).map(
-              (v) => {
-                return (
-                  <li key={v.createdTime}>
-                    <Album albumData={v} />
-                  </li>
-                );
-              },
-            )}
+            {(selectedOption === 'oldest'
+              ? oldestAlbumList
+              : albumDataList
+            ).map((v) => {
+              return (
+                <li key={v.createdTime}>
+                  <Album albumData={v} />
+                </li>
+              );
+            })}
           </ul>
           {isAddModalOpen && <NewAlbumModal onClose={HandleAddCloseModal} />}
           {isArrayModalOpen && (


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가


### 반영 브랜치
ex) Feat/home ->main

### 변경 사항
useGetAlbumList 훅에서 useEffect에 의존성 배열을 collection으로 지정했습니다.
onSnapshot 함수를 사용해 collection의 값이 변할 때 마다 데이터를 읽고 값을 받아왔습니다.
