### PR TITLE
Fix: 게시물 수정 - 같은 이미지로 변경 시, 변경된 이미지 URL이 404인 에러 수정

### DIFF
--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -42,8 +42,8 @@ const Carousel = ({ imgUrlList }: { imgUrlList: string[] }) => {
       <Styled.SlideImgWrap>
         <ul ref={slideRef}>
           {imgUrlList.map((image, index) => (
-            <li>
-              <img key={index} src={image} alt="이미지" />
+            <li key={index}>
+              <img src={image} alt="이미지" />
             </li>
           ))}
         </ul>

--- a/src/components/Upload/EditFeed.tsx
+++ b/src/components/Upload/EditFeed.tsx
@@ -187,7 +187,6 @@ export default function EditFeed() {
       });
 
       // 이미지 삭제 실패 시, 게시물 수정이 중단되지 않도록 try 마지막에 위치
-      console.log(downloadURLs, imgUrlList);
       if (file !== null) {
         for (let i = downloadURLs.length; i < 3; i++)
           if (!downloadURLs.includes(imgUrlList[i])) {

--- a/src/components/Upload/EditFeed.tsx
+++ b/src/components/Upload/EditFeed.tsx
@@ -187,8 +187,12 @@ export default function EditFeed() {
       });
 
       // 이미지 삭제 실패 시, 게시물 수정이 중단되지 않도록 try 마지막에 위치
+      console.log(downloadURLs, imgUrlList);
       if (file !== null) {
-        imgUrlList.forEach(async (url) => await deleteImg(url));
+        for (let i = downloadURLs.length; i < 3; i++)
+          if (!downloadURLs.includes(imgUrlList[i])) {
+            await deleteImg(imgUrlList[i]);
+          }
       }
     } catch (error) {
       console.error(error);

--- a/src/components/Upload/UploadImageToStorage.tsx
+++ b/src/components/Upload/UploadImageToStorage.tsx
@@ -11,9 +11,9 @@ const uploadImageToStorage = async (
   feedId: string,
 ) => {
   const storage = getStorage();
-  const downloadURLs: string[] = [];
-  const uploadPromises = Array.from(files).map((file) => {
-    const storageRef = ref(storage, `${folderName}/${feedId}${file.name}`);
+  const downloadURLs: (string | null)[] = [...files].map(() => null);
+  const uploadPromises = Array.from(files).map((file, i) => {
+    const storageRef = ref(storage, `${folderName}/${feedId}${i}`);
     const uploadTask = uploadBytesResumable(storageRef, file);
 
     return new Promise((resolve, reject) => {
@@ -39,7 +39,7 @@ const uploadImageToStorage = async (
         async () => {
           try {
             const downloadURL = await getDownloadURL(uploadTask.snapshot.ref);
-            downloadURLs.push(downloadURL);
+            downloadURLs[i] = downloadURL;
 
             resolve(undefined);
           } catch (error) {

--- a/src/components/Upload/UploadImageToStorage.tsx
+++ b/src/components/Upload/UploadImageToStorage.tsx
@@ -11,7 +11,7 @@ const uploadImageToStorage = async (
   feedId: string,
 ) => {
   const storage = getStorage();
-  const downloadURLs: (string | null)[] = [...files].map(() => null);
+  const downloadURLs: string[] = [...files].map(() => '');
   const uploadPromises = Array.from(files).map((file, i) => {
     const storageRef = ref(storage, `${folderName}/${feedId}${i}`);
     const uploadTask = uploadBytesResumable(storageRef, file);

--- a/src/utils/SDKUtils.ts
+++ b/src/utils/SDKUtils.ts
@@ -3,7 +3,7 @@ import {
   ref,
   deleteObject,
   getDownloadURL,
-  uploadBytesResumable,
+  uploadBytes,
 } from 'firebase/storage';
 
 import { storage, appAuth } from '../firebase/config.ts';
@@ -24,9 +24,8 @@ async function deleteImg(url: string) {
 
 async function uploadImg(path: string, file: File) {
   const storageRef = ref(storage, path);
-  const uploadTask = uploadBytesResumable(storageRef, file);
-
-  const downloadURL = await getDownloadURL(uploadTask.snapshot.ref);
+  const uploadTask = await uploadBytes(storageRef, file);
+  const downloadURL = await getDownloadURL(uploadTask.ref);
   return downloadURL;
 }
 


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
fix/editFeed -> main

### 변경 사항
- Style: utils - 이미지 업로드 시 사용하는 파이어베이스 메서드 변경
  - pause(), resume(), cancel() 메서드를 사용하지 않으므로, uploadBytesResumable -> uploadBytes 메서드로 변경
- Fix: 게시물 수정 - 같은 이미지로 변경 시, 변경된 이미지 URL이 404인 에러 수정
  - storage에 file 업로드 및 삭제
  1. storage에 업로드되어 있는 path와 동일한 path로 업로드 시,  기존 URL은 삭제되지 않고, 새로운 URL이 생성된다.
  2. 둘 중 1개의 URL로 해당 file을 삭제해도, 두 URL 모두 접속 시 404가 뜬다.
  - 기존 로직
  1. 변경된 이미지들을 업로드 후, 해당 게시물의 기존 이미지들을 URL로 삭제.
  2. path가 동일한 경우, 변경된 이미지도 삭제됨
  3. 게시물 상세에서 삭제된 이미지(URL)는 엑박으로 나타남
  - 해결
  1. path가 무작위로 겹치는 경우가 생기지 않도록 path 네이밍 변경(uid/feedId+fileName -> uid/feedId+index)
  2. 변경된 이미지 수가 이전 이미지 수보다 많을 경우, 겹치지 않는 인덱스부터 이미지 삭제