### PR TITLE
:bug: Fix: 앨범 배경 이미지가 렌더링되지 않는 버그 수정(#201)

### DIFF
--- a/src/components/Album/StyledAlbum.ts
+++ b/src/components/Album/StyledAlbum.ts
@@ -11,10 +11,14 @@ const AlbumContainer = styled.article<Props>`
   width: 100%;
   height: 100%;
   border-radius: 1rem;
-  background: ${(props) =>
-    props.$imageUrl && props.$imageUrl.length > 0
-      ? `linear-gradient(0deg, #343434 5.58%, rgba(126, 126, 126, 0) 40.58%, rgba(225, 225, 225, 0) 105.15%), url(${props.$imageUrl[0]}) no-repeat center / cover`
-      : 'linear-gradient(0deg, #343434 5.58%, rgba(126, 126, 126, 0) 40.58%, rgba(225, 225, 225, 0) 105.15%), var(--gray-200)'};
+  background: ${(props) => {
+    const imageUrl: string | undefined = props.$imageUrl?.[0];
+
+    if (!imageUrl) {
+      return 'linear-gradient(0deg, #343434 5.58%, rgba(126, 126, 126, 0) 40.58%, rgba(225, 225, 225, 0) 105.15%), var(--gray-200)';
+    } else
+      return `linear-gradient(0deg, #343434 5.58%, rgba(126, 126, 126, 0) 40.58%, rgba(225, 225, 225, 0) 105.15%), url('${imageUrl}') no-repeat center / cover`;
+  }};
   .txtWrapper {
     width: 100%;
     position: absolute;

--- a/src/pages/Home/StyledHome.ts
+++ b/src/pages/Home/StyledHome.ts
@@ -84,10 +84,16 @@ const StyledHomeSection = styled.section`
       height: 3rem;
       background-color: inherit;
     }
+    .array-modal {
+      top: 26%;
+    }
   }
   @media (max-width: 430px) {
     ul {
       display: flex;
+    }
+    .array-modal {
+      top: 13%;
     }
   }
 `;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 버그 수정


### 반영 브랜치
ex) Refactor/home ->  main

### 변경 사항
기존 코드
```js
background: ${(props) =>
    props.$imageUrl && props.$imageUrl.length > 0
      ? `linear-gradient(0deg, #343434 5.58%, rgba(126, 126, 126, 0) 40.58%, rgba(225, 225, 225, 0) 105.15%), url(${props.$imageUrl[0]}) no-repeat center / cover`
      : 'linear-gradient(0deg, #343434 5.58%, rgba(126, 126, 126, 0) 40.58%, rgba(225, 225, 225, 0) 105.15%), var(--gray-200)'};

```
{props.$imageUrl[0]}에 들어오는값에 괄호가 있을시 url 속성의 닫는 괄호로 인식되어 버그 발생

수정코드

```js
background: ${(props) => {
    const imageUrl: string | undefined = props.$imageUrl?.[0];

    if (!imageUrl) {
      return 'linear-gradient(0deg, #343434 5.58%, rgba(126, 126, 126, 0) 40.58%, rgba(225, 225, 225, 0) 105.15%), var(--gray-200)';
    } else
      return `linear-gradient(0deg, #343434 5.58%, rgba(126, 126, 126, 0) 40.58%, rgba(225, 225, 225, 0) 105.15%), url('${imageUrl}') no-repeat center / cover`;
  }};
```
imageUrl라는 변수에 할당한후 템플릿리터럴 안에 넣음으로 문자열의 주솟값을 온전히 전달할수 있게 됨