### PR TITLE
fix : dialog 태그 수정 및 업로드 모달에 적용

### DIFF
--- a/src/GlobalStyle.tsx
+++ b/src/GlobalStyle.tsx
@@ -109,13 +109,9 @@ const GlobalStyle = createGlobalStyle`
     height: 100%;
   }
 
-  dialog {
-    padding: 0;
-    border: none;
-  }
-  
-  dialog::backdrop {
-    display: none;
+   dialog::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(5px);
   }
 `;
 

--- a/src/GlobalStyle.tsx
+++ b/src/GlobalStyle.tsx
@@ -111,7 +111,6 @@ const GlobalStyle = createGlobalStyle`
 
    dialog::backdrop {
   background: rgba(0, 0, 0, 0.5);
-  /* backdrop-filter: blur(5px); */
   }
 `;
 

--- a/src/GlobalStyle.tsx
+++ b/src/GlobalStyle.tsx
@@ -111,7 +111,7 @@ const GlobalStyle = createGlobalStyle`
 
    dialog::backdrop {
   background: rgba(0, 0, 0, 0.5);
-  backdrop-filter: blur(5px);
+  /* backdrop-filter: blur(5px); */
   }
 `;
 

--- a/src/components/Upload/Upload/StyledUpload.ts
+++ b/src/components/Upload/Upload/StyledUpload.ts
@@ -1,13 +1,14 @@
 import styled from 'styled-components';
 
-const UploadWrapper = styled.div`
-  position: relative;
-  overflow: hidden;
+const StyledDialog = styled.dialog`
   max-width: 80rem;
   width: 100%;
   border-radius: 10px;
   background-color: var(--background-color);
   color: var(--gray-900);
+  border: none;
+  padding: 0;
+  overflow: hidden;
   z-index: 1001;
 
   @media (min-width: 1025px) {
@@ -213,11 +214,12 @@ const CloseBtn = styled.button`
   top: 2rem;
   right: 2rem;
   background-color: transparent;
-  z-index: 101;
+  z-index: 1010;
+  cursor: pointer;
 `;
 
 export {
-  UploadWrapper,
+  StyledDialog,
   MobileCloseBtn,
   UploadHeader,
   UploadContents,

--- a/src/components/Upload/Upload/Upload.tsx
+++ b/src/components/Upload/Upload/Upload.tsx
@@ -35,8 +35,12 @@ function Upload() {
   const navigate = useNavigate();
   const dialogRef = useRef<HTMLDialogElement>(null);
   const { user } = useAuthContext();
-  const { albumNameListToAdd, isUploadModalOpen, setIsUploadModalOpen } =
-    useUploadContext();
+  const {
+    albumNameListToAdd,
+    isUploadModalOpen,
+    setIsUploadModalOpen,
+    setAlbumNameListToAdd,
+  } = useUploadContext();
 
   const [kakaoMapVisible, setKakaoMapVisible] = useState(false);
   const [title, setTitle] = useState('');
@@ -81,6 +85,7 @@ function Upload() {
       dialogRef.current.close();
     }
     setIsUploadModalOpen(false);
+    setAlbumNameListToAdd(albumNameListToAdd.slice(0, 1));
   };
 
   // 'ESC' 키 이벤트와 `close` 이벤트 리스너를 추가하여 모달 상태를 동기화

--- a/src/components/Upload/Upload/Upload.tsx
+++ b/src/components/Upload/Upload/Upload.tsx
@@ -1,4 +1,4 @@
-import { SyntheticEvent, useState, useEffect } from 'react';
+import { SyntheticEvent, useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import { appFireStore, Timestamp } from '../../../firebase/config';
@@ -11,7 +11,6 @@ import useAuthContext from '../../../hooks/useAuthContext';
 import Accordion from '../../Accordion/Accordion';
 import GetAccordionData from '../GetAccordionData';
 import MultipleAccordion from '../../Accordion/MultipleAccordion';
-import ModalOverlay from '../../CommonStyled/StyledModalOverlay';
 import Preview from '../../FileUpload/Preview';
 import uploadImageToStorage from '../UploadImageToStorage';
 import KakaoMap from '../../Map/KakaoMap';
@@ -33,8 +32,10 @@ interface AlbumIdData {
 }
 
 function Upload() {
+  const navigate = useNavigate();
+  const dialogRef = useRef<HTMLDialogElement>(null);
   const { user } = useAuthContext();
-  const { albumNameListToAdd, setIsUploadModalOpen, setAlbumNameListToAdd } =
+  const { albumNameListToAdd, isUploadModalOpen, setIsUploadModalOpen } =
     useUploadContext();
 
   const [kakaoMapVisible, setKakaoMapVisible] = useState(false);
@@ -69,16 +70,36 @@ function Upload() {
     setKakaoMapVisible(!kakaoMapVisible);
   };
 
+  useEffect(() => {
+    if (isUploadModalOpen && dialogRef.current) {
+      dialogRef.current.showModal();
+    }
+  }, [isUploadModalOpen]);
+
   const closeUploadModal = () => {
+    if (dialogRef.current) {
+      dialogRef.current.close();
+    }
     setIsUploadModalOpen(false);
-    setAlbumNameListToAdd(albumNameListToAdd.slice(0, 1));
   };
+
+  // 'ESC' 키 이벤트와 `close` 이벤트 리스너를 추가하여 모달 상태를 동기화
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    const handleClose = () => {
+      setIsUploadModalOpen(false);
+    };
+
+    dialog?.addEventListener('close', handleClose);
+
+    return () => {
+      dialog?.removeEventListener('close', handleClose);
+    };
+  }, [setIsUploadModalOpen]);
 
   const handleAddressSelect = (selectedAddress: string) => {
     setSelectedAddress(selectedAddress);
   };
-
-  const navigate = useNavigate();
 
   const handleSubmit = async (e: SyntheticEvent) => {
     e.preventDefault();
@@ -150,8 +171,12 @@ function Upload() {
   };
 
   return (
-    <ModalOverlay>
-      <Styled.UploadWrapper className={isPending ? 'loading' : ''}>
+    <>
+      <Styled.StyledDialog
+        className={isPending ? 'loading' : ''}
+        ref={dialogRef}
+        aria-labelledby="dialog-label"
+      >
         <h2 className="a11y-hidden">새 게시물 업로드</h2>
         <Styled.UploadHeader>
           <h2>새 게시물</h2>
@@ -247,11 +272,14 @@ function Upload() {
             </>
           )}
         </Styled.UploadContents>
-      </Styled.UploadWrapper>
-      <Styled.CloseBtn className="closeBtn" onClick={() => closeUploadModal()}>
-        <img src={CloseIcon} alt="닫기버튼" />
-      </Styled.CloseBtn>
-    </ModalOverlay>
+        <Styled.CloseBtn
+          className="closeBtn"
+          onClick={() => closeUploadModal()}
+        >
+          <img src={CloseIcon} alt="닫기버튼" />
+        </Styled.CloseBtn>
+      </Styled.StyledDialog>
+    </>
   );
 }
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 버그 수정
- [x] 스타일


### 반영 브랜치
feat/login -> main

### 변경 사항
- div -> dialog 태그로 수정하여 기본 dialog 제공 기능 사용했습니다.
- 업로드 모달 dialog 태그 수정 후 -> esc로 닫은 업로드 모달이 다시 뜨지 않는 오류 발생
✅ 이유 : 기본적으로 dialog의 ESC 키 동작은 DOM 요소의 상태를 변경하지만, React 컴포넌트의 상태(isUploadModalOpen)를 업데이트하지 않는다. 사용자가 ESC를 눌러 모달을 닫으면 실제 DOM 요소는 닫히지만, React의 상태는 여전히 모달이 열려 있다고 인식한다.이 상태 불일치로 인해 모달을 다시 열려고 할 때 문제가 발생
✅ 해결 방법 : dialog 요소의 close 이벤트를 감지하고, 이 이벤트가 발생했을 때 setIsUploadModalOpen(false)를 호출하여 React 상태를 업데이트하여 ESC 키로 모달을 닫았을 때와 사용자가 모달을 다른 방식으로 닫았을 때 모두 상태가 일관되게 관리하여 해결합니다.

### 테스트 결과 (없을 경우 생략)


### 실행 결과 스크린샷 (없을 경우 생략)
