### PR TITLE
Fix: 회원가입/프로필 수정 - 프로필 이미지 유효성

### DIFF
--- a/src/GlobalStyle.tsx
+++ b/src/GlobalStyle.tsx
@@ -39,7 +39,7 @@ const GlobalStyle = createGlobalStyle`
     --gray-800:#393939;
     --gray-900:#1F1F1F;
 
-    --error-color: #DE3F35;
+--error-color: #DE3F35;
 
     --serif : 'Prata', serif;
     --title-font-family : 'Prata', 'Noto Sans', sans-serif;
@@ -100,9 +100,14 @@ const GlobalStyle = createGlobalStyle`
     width: 100%;
     height: 100%;
   }
+  
+  dialog {
+    padding: 0;
+    border: none;
+  }
 
-   dialog::backdrop {
-  background: rgba(0, 0, 0, 0.5);
+  dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
   }
 `;
 

--- a/src/components/FileUpload/Preview.tsx
+++ b/src/components/FileUpload/Preview.tsx
@@ -143,7 +143,7 @@ const Preview = ({
 
       {submitErrMessage && (
         <AlertModal
-          title={submitErrMessage}
+          message={submitErrMessage}
           onClose={() => setSubmitErrMessage('')}
         />
       )}

--- a/src/components/Modal/AlertModal/AlertModal.tsx
+++ b/src/components/Modal/AlertModal/AlertModal.tsx
@@ -3,10 +3,10 @@ import ModalOverlay from '../../CommonStyled/StyledModalOverlay';
 import { useRef } from 'react';
 
 export default function AlertModal({
-  title,
+  message,
   onClose,
 }: {
-  title: string;
+  message: string;
   onClose: () => void;
 }) {
   const dialogRef = useRef<HTMLDialogElement>();
@@ -22,7 +22,7 @@ export default function AlertModal({
         }}
         aria-labelledby="dialog-label"
       >
-        <h3 id="dialog-label">{title}</h3>
+        <p id="dialog-label">{message}</p>
         <button type="button" onClick={onClose}>
           확인
         </button>

--- a/src/components/Modal/AlertModal/StyledAlertModal.ts
+++ b/src/components/Modal/AlertModal/StyledAlertModal.ts
@@ -6,7 +6,7 @@ const StyledAlertModal = styled.dialog`
   border-radius: 1rem;
   background: var(--background-color);
 
-  h3 {
+  p {
     padding: 22px 30px;
     font-size: var(--text-l);
     word-break: keep-all;

--- a/src/components/MyNonModal/MyNonModal.tsx
+++ b/src/components/MyNonModal/MyNonModal.tsx
@@ -115,7 +115,7 @@ export default function MyNonModal({ setIsDialogOpen }: Props) {
       )}
       {submitErrMessage && (
         <AlertModal
-          title={submitErrMessage}
+          message={submitErrMessage}
           onClose={() => setSubmitErrMessage('')}
         />
       )}

--- a/src/hooks/useSetProfileImage.ts
+++ b/src/hooks/useSetProfileImage.ts
@@ -19,7 +19,7 @@ export default function useSetProfileImage() {
       return;
     }
 
-    if (fileToChange.size > 1 * 1024 * 1024) {
+    if (fileToChange.size > 10 * 1024 * 1024) {
       setError('이미지 용량은 10MB 이내로 등록 가능합니다.');
       return;
     }

--- a/src/hooks/useSetProfileImage.ts
+++ b/src/hooks/useSetProfileImage.ts
@@ -40,5 +40,5 @@ export default function useSetProfileImage() {
     });
   };
 
-  return { setProfileImage, file, setFile, src, setSrc, error };
+  return { setProfileImage, file, setFile, src, setSrc, error, setError };
 }

--- a/src/pages/EditProfile/EditProfile.tsx
+++ b/src/pages/EditProfile/EditProfile.tsx
@@ -282,6 +282,9 @@ export default function EditProfile() {
               id="profile-inp"
               type="file"
               className="a11y-hidden"
+              onClick={(e) =>
+                ((e.currentTarget as HTMLInputElement).value = '')
+              }
               onChange={(e) => setProfileImage(e.target.files)}
               onFocus={() => setImgHasFocus(true)}
               onBlur={() => setImgHasFocus(false)}

--- a/src/pages/EditProfile/EditProfile.tsx
+++ b/src/pages/EditProfile/EditProfile.tsx
@@ -395,7 +395,7 @@ export default function EditProfile() {
         )}
         {submitErrMessage && (
           <AlertModal
-            title={submitErrMessage}
+            message={submitErrMessage}
             onClose={() => {
               setSubmitErrMessage('');
               setSelectedBtn('프로필 수정');
@@ -404,7 +404,7 @@ export default function EditProfile() {
         )}
         {imgErrMessage && (
           <AlertModal
-            title={imgErrMessage}
+            message={imgErrMessage}
             onClose={() => setImgErrMessage('')}
           />
         )}

--- a/src/pages/EditProfile/EditProfile.tsx
+++ b/src/pages/EditProfile/EditProfile.tsx
@@ -62,7 +62,8 @@ export default function EditProfile() {
     setSrc,
     src,
     setProfileImage,
-    error: selectImgError,
+    error: imgErrMessage,
+    setError: setImgErrMessage,
   } = useSetProfileImage();
 
   useEffect(() => {
@@ -70,12 +71,6 @@ export default function EditProfile() {
       setClientWitch(document.documentElement.clientWidth);
     });
   }, []);
-
-  useEffect(() => {
-    if (selectImgError) {
-      setSubmitErrMessage(selectImgError);
-    }
-  }, [selectImgError]);
 
   useEffect(() => {
     setSubmitErrMessage('');
@@ -287,7 +282,7 @@ export default function EditProfile() {
               id="profile-inp"
               type="file"
               className="a11y-hidden"
-              onChange={setProfileImage}
+              onChange={(e) => setProfileImage(e.target.files)}
               onFocus={() => setImgHasFocus(true)}
               onBlur={() => setImgHasFocus(false)}
             />
@@ -402,6 +397,12 @@ export default function EditProfile() {
               setSubmitErrMessage('');
               setSelectedBtn('프로필 수정');
             }}
+          />
+        )}
+        {imgErrMessage && (
+          <AlertModal
+            title={imgErrMessage}
+            onClose={() => setImgErrMessage('')}
           />
         )}
       </StyledEditProfile>

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -152,7 +152,7 @@ export default function Login() {
 
         {submitErrMessage && (
           <AlertModal
-            title={submitErrMessage}
+            message={submitErrMessage}
             onClose={() => setSubmitErrMessage('')}
           />
         )}

--- a/src/pages/My/My.tsx
+++ b/src/pages/My/My.tsx
@@ -87,7 +87,7 @@ export default function My() {
 
         {submitErrMessage && (
           <AlertModal
-            title={submitErrMessage}
+            message={submitErrMessage}
             onClose={() => setSubmitErrMessage('')}
           />
         )}

--- a/src/pages/Signup/Signup.tsx
+++ b/src/pages/Signup/Signup.tsx
@@ -47,7 +47,13 @@ export default function Signup() {
   const [imgHasFocus, setImgHasFocus] = useState(false);
 
   const { error, signup, isPending } = useSignup();
-  const { file, src, setProfileImage } = useSetProfileImage();
+  const {
+    file,
+    src,
+    setProfileImage,
+    error: imgErrMessage,
+    setError: setImgErrMessage,
+  } = useSetProfileImage();
 
   const prevPath = useSelector(
     (state: RootState) => state.pageReducer.prevPath,
@@ -422,6 +428,12 @@ export default function Signup() {
           <AlertModal
             title={submitErrMessage}
             onClose={() => setSubmitErrMessage('')}
+          />
+        )}
+        {imgErrMessage && (
+          <AlertModal
+            title={imgErrMessage}
+            onClose={() => setImgErrMessage('')}
           />
         )}
       </StyledSignup>

--- a/src/pages/Signup/Signup.tsx
+++ b/src/pages/Signup/Signup.tsx
@@ -256,6 +256,9 @@ export default function Signup() {
               id="profile-inp"
               type="file"
               className="a11y-hidden"
+              onClick={(e) =>
+                ((e.currentTarget as HTMLInputElement).value = '')
+              }
               onChange={(e) => {
                 setProfileImage(e.target.files);
                 setProfileImgFiles(e.target.files);

--- a/src/pages/Signup/Signup.tsx
+++ b/src/pages/Signup/Signup.tsx
@@ -429,13 +429,13 @@ export default function Signup() {
 
         {submitErrMessage && (
           <AlertModal
-            title={submitErrMessage}
+            message={submitErrMessage}
             onClose={() => setSubmitErrMessage('')}
           />
         )}
         {imgErrMessage && (
           <AlertModal
-            title={imgErrMessage}
+            message={imgErrMessage}
             onClose={() => setImgErrMessage('')}
           />
         )}


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정
- [x] 스타일

### 반영 브랜치
Fix/profileImgUpload -> main

### 변경 사항
- 이슈 참고
- **다른 input file에도 적용해주세요**
이미지 선택 전, input value 초기화
=> 이전과 같은 이미지를 선택해도 onChange 이벤트 작동
=> 유효하지 않은 파일을 선택할 때마다 alertModal 렌더링
```js
onClick={(e) =>
  ((e.currentTarget as HTMLInputElement).value = '')
}```